### PR TITLE
SB3 - 03x03 - Documentación de la API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,11 @@
 			<version>4.2.0</version>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/med/voll/api/controller/ConsultaController.java
+++ b/src/main/java/med/voll/api/controller/ConsultaController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import med.voll.api.domain.consulta.AgendaDeConsultaService;
@@ -15,6 +16,7 @@ import med.voll.api.domain.consulta.DatosDetalleConsulta;
 
 @RestController
 @RequestMapping("/consultas")
+@SecurityRequirement(name = "bearer-key")
 public class ConsultaController {
 
     @Autowired

--- a/src/main/java/med/voll/api/controller/MedicoController.java
+++ b/src/main/java/med/voll/api/controller/MedicoController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import med.voll.api.domain.medico.DatosActualizarMedico;
@@ -28,6 +29,7 @@ import med.voll.api.domain.medico.MedicoRepository;
 
 @RestController
 @RequestMapping("/medicos")
+@SecurityRequirement(name = "bearer-key")
 public class MedicoController {
 
     @Autowired

--- a/src/main/java/med/voll/api/controller/PacienteController.java
+++ b/src/main/java/med/voll/api/controller/PacienteController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import med.voll.api.domain.paciente.DatosActualizacionPaciente;
 import med.voll.api.domain.paciente.DatosDetallesPaciente;
@@ -27,6 +28,7 @@ import med.voll.api.domain.paciente.PacienteRepository;
 
 @RestController
 @RequestMapping("/pacientes")
+@SecurityRequirement(name = "bearer-key")
 public class PacienteController {
 
     @Autowired

--- a/src/main/java/med/voll/api/infra/security/SecurityConfigurations.java
+++ b/src/main/java/med/voll/api/infra/security/SecurityConfigurations.java
@@ -29,6 +29,7 @@ public class SecurityConfigurations {
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         // .requestMatchers(HttpMethod.DELETE, "/medicos").hasRole("ADMIN")   // Ejemplo de proteger ruta por rol
                         .anyRequest().authenticated())
                         .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/med/voll/api/infra/springdoc/SpringDocConfiguration.java
+++ b/src/main/java/med/voll/api/infra/springdoc/SpringDocConfiguration.java
@@ -1,0 +1,39 @@
+package med.voll.api.infra.springdoc;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SpringDocConfiguration {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .info(new Info()
+                        .title("API Voll.med")
+                        .description(
+                                "API Rest de la aplicación Voll.med, que contiene las funcionalidades de CRUD de médicos y pacientes, así como programación y cancelación de consultas.")
+                        .contact(new Contact()
+                                .name("Equipo Backend")
+                                .email("backend@voll.med"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("http://voll.med/api/licencia")));
+    }
+
+    @Bean
+    public void message() {
+        System.out.println("Bearer is working");
+    }
+
+}


### PR DESCRIPTION
- Agregar la biblioteca SpringDoc al proyecto para que genere automáticamente la documentación de la API;
- Analizar la documentación de SpringDoc para comprender cómo configurarlo en un proyecto;
- Acceder a las direcciones que brindan la documentación de la API en formatos yaml y html;
- Utilizar la interfaz de usuario de Swagger para visualizar y probar una API Rest;
- Configurar JWT en la documentación generada por SpringDoc.